### PR TITLE
Add drift by transform

### DIFF
--- a/examples/CreatingRotationSeriesWithDrift.ipynb
+++ b/examples/CreatingRotationSeriesWithDrift.ipynb
@@ -1,0 +1,451 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Creating Rotation Series\n",
+    "Here we describe multiple ways to generate a series of scan distorted images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###### Loads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<style>\n",
+       ".jp-OutputArea-prompt:empty {\n",
+       "  padding: 0;\n",
+       "  border: 0;\n",
+       "}\n",
+       "</style>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%matplotlib widget\n",
+    "\n",
+    "# This thing just saves some whitespace from a bug in tqdm / notebook\n",
+    "from IPython.display import HTML\n",
+    "display(HTML(\"\"\"\n",
+    "<style>\n",
+    ".jp-OutputArea-prompt:empty {\n",
+    "  padding: 0;\n",
+    "  border: 0;\n",
+    "}\n",
+    "</style>\n",
+    "\"\"\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from importlib import reload\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from genSTEM import Model\n",
+    "\n",
+    "from ase.spacegroup import crystal\n",
+    "from ase.build import make_supercell, bulk\n",
+    "from ase.visualize.plot import plot_atoms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Build a model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build the structure with ase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(12, 3)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6d202c33188346ddbee86437c91a9971",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a=4.0\n",
+    "atoms = bulk('Al', 'fcc', a=a, cubic=True)\n",
+    "atoms = make_supercell(atoms, np.diag([8,8,1]))\n",
+    "\n",
+    "plateX = atoms.positions[:,0]==a*8/4\n",
+    "plateY = atoms.positions[:,1]>=a*8/4\n",
+    "\n",
+    "plate = plateX&plateY\n",
+    "print(atoms.positions[plate].shape)\n",
+    "\n",
+    "atoms.numbers[plate] = 29\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "plot_atoms(atoms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Build the image with genSTEM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can create a series of STEM images with or without defects associated with serial image aquisition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8980ea190fe94762935ad4513abe9d24",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Size: 0.000739328 GB\n",
+      "Shape: (4, 152, 152)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "59b07f2b8a9348bfadfae0265afe6630",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "images, scanangles, *_ = Model.get_rotation_series(atoms, vacuum=0,\n",
+    "                                                   pixel_size=0.2, nImages=4, maxScanAngle=360,\n",
+    "                                                   drift_speed=0, drift_angle=0, jitter_strength=0)\n",
+    "\n",
+    "ncols = 4 if len(images) > 4 else len(images)\n",
+    "mult = 12 / ncols\n",
+    "nrows = len(images) // ncols if len(images) % ncols == 0 else len(images) // ncols +1\n",
+    "rowcols = np.array([nrows, ncols])\n",
+    "\n",
+    "fig, axs = plt.subplots(*rowcols, figsize=mult*rowcols[::-1])\n",
+    "for ax, img, ang in zip(axs.flatten(), images, scanangles):\n",
+    "    ax.imshow(img.get(), cmap='jet')\n",
+    "    ax.text(0,0, ang, va='top', bbox=dict(facecolor='w', alpha=0.7), clip_on=True)\n",
+    "    ax.axis('off')\n",
+    "fig.tight_layout(pad=0, w_pad=0.1, h_pad=0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have multiple ways to add drift to an image.  Since we know the drift is acumulated ofver time we can add drift using a pixels index as time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "989eb3b2c8d24fcea9103ed391e9cb30",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Size: 0.000739328 GB\n",
+      "Shape: (4, 152, 152)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "234d53d8b55e4a0b9ddf80ddfd10632d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "images, scanangles, *_ = Model.get_rotation_series(atoms, vacuum=0,\n",
+    "                                                   pixel_size=0.2, nImages=4, maxScanAngle=360,\n",
+    "                                                   drift_speed=12, drift_angle=45, jitter_strength=0,\n",
+    "                                                   centre_drift=True, periodic_boundary=False,\n",
+    "                                                   drift_by_transform=False)\n",
+    "\n",
+    "ncols = 4 if len(images) > 4 else len(images)\n",
+    "mult = 12 / ncols\n",
+    "nrows = len(images) // ncols if len(images) % ncols == 0 else len(images) // ncols +1\n",
+    "rowcols = np.array([nrows, ncols])\n",
+    "\n",
+    "fig, axs = plt.subplots(*rowcols, figsize=mult*rowcols[::-1])\n",
+    "for ax, img, ang in zip(axs.flatten(), images, scanangles):\n",
+    "    ax.imshow(img.get(), cmap='jet')\n",
+    "    ax.text(0,0, ang, va='top', bbox=dict(facecolor='w', alpha=0.7), clip_on=True)\n",
+    "    ax.axis('off')\n",
+    "fig.tight_layout(pad=0, w_pad=0.1, h_pad=0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, we can add drift using affine transforms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de3da9fc5e2c445da6423a73fb5d17ce",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Size: 0.000739328 GB\n",
+      "Shape: (4, 152, 152)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dfbcb0d156194a02a984b099d5011319",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "images, scanangles, *_ = Model.get_rotation_series(atoms, vacuum=0,\n",
+    "                                                   pixel_size=0.2, nImages=4, maxScanAngle=360,\n",
+    "                                                   drift_speed=12, drift_angle=45, jitter_strength=0,\n",
+    "                                                   centre_drift=False, periodic_boundary=False,\n",
+    "                                                   drift_by_transform=True, kwargs_affine={'mode':'constant', 'cval':0})\n",
+    "\n",
+    "ncols = 4 if len(images) > 4 else len(images)\n",
+    "mult = 12 / ncols\n",
+    "nrows = len(images) // ncols if len(images) % ncols == 0 else len(images) // ncols +1\n",
+    "rowcols = np.array([nrows, ncols])\n",
+    "\n",
+    "fig, axs = plt.subplots(*rowcols, figsize=mult*rowcols[::-1])\n",
+    "for ax, img, ang in zip(axs.flatten(), images, scanangles):\n",
+    "    ax.imshow(img.get(), cmap='jet')\n",
+    "    ax.text(0,0, ang, va='top', bbox=dict(facecolor='w', alpha=0.7), clip_on=True)\n",
+    "    ax.axis('off')\n",
+    "fig.tight_layout(pad=0, w_pad=0.1, h_pad=0.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To include periodic boundary conditions by tiling the input atoms cell or wrap around from drift.  The later is much faster but can produce image artifacts from boudnary conditions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "15d4a55600ba4794a5e8a5e9f1111fef",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Size: 0.000739328 GB\n",
+      "Shape: (4, 152, 152)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a4caf9d1ee67474b9e65968dc36f05dc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "images, scanangles, *_ = Model.get_rotation_series(atoms, vacuum=0,\n",
+    "                                                   pixel_size=0.2, nImages=4, maxScanAngle=360,\n",
+    "                                                   drift_speed=12, drift_angle=45, jitter_strength=0,\n",
+    "                                                   centre_drift=True, periodic_boundary=True,\n",
+    "                                                   drift_by_transform=False)\n",
+    "\n",
+    "ncols = 4 if len(images) > 4 else len(images)\n",
+    "mult = 12 / ncols\n",
+    "nrows = len(images) // ncols if len(images) % ncols == 0 else len(images) // ncols +1\n",
+    "rowcols = np.array([nrows, ncols])\n",
+    "\n",
+    "fig, axs = plt.subplots(*rowcols, figsize=mult*rowcols[::-1])\n",
+    "for ax, img, ang in zip(axs.flatten(), images, scanangles):\n",
+    "    ax.imshow(img.get(), cmap='jet')\n",
+    "    ax.text(0,0, ang, va='top', bbox=dict(facecolor='w', alpha=0.7), clip_on=True)\n",
+    "    ax.axis('off')\n",
+    "fig.tight_layout(pad=0, w_pad=0.1, h_pad=0.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/genSTEM/Model.py
+++ b/genSTEM/Model.py
@@ -138,43 +138,7 @@ def plot(points, ax, lim=((),())):
         ax.set_ylim(ymax, ymin)
     else:
         ax.set_xlim(lim[0])
-        ax.set_ylim(lim[1])  
-        
-def extend_3D_ones(arr_of_2d):
-    '''Turn a 2D points array (N, 2) into (N, 3) by padding with ones.
-    Used to calculate transform matrix between two sets of points.
-    '''
-    return np.hstack([arr_of_2d, np.ones((len(arr_of_2d),1))])
-    
-def calculate_transform_matrix(points, prime):
-    '''Calculate the affine transform matrix needed to turn one set of points into another.
-
-    Parameters
-    ----------
-    points: array of shape (N, 2)
-    prime: array of shape (N, 2)
-
-    Returns
-    -------
-    transform matrix: array of shape (3,3)
-    '''
-    points = extend_3D_ones(points)
-    prime = extend_3D_ones(prime)
-    T, *_ = np.linalg.lstsq(points, prime, rcond=None)
-    return T.T
-
-def transform_points(points: "(2, N)", transform: "(3,3)"):
-    '''Transform a 2D points array (2, N) by a 3x3 transform
-
-    Turns the list of points into a (N, 3)  array, transforms
-    and then removes the third coordinate again.
-    Supports cp as well!
-    '''
-    shape = points.shape
-    points = points.reshape((2, -1))
-    points = extend_3D_ones(points.T).T
-    prime = transform @ points
-    return prime[:2].reshape(shape)
+        ax.set_ylim(lim[1])
 
 def get_and_plot_peaks(data, average_distance_between_peaks=80, threshold = 1):
     import scipy.ndimage as ndimage

--- a/genSTEM/Model.py
+++ b/genSTEM/Model.py
@@ -453,6 +453,7 @@ class ImageModel:
         self.scan_rotation = scan_rotation
         self.square = square
         self.margin = vacuum
+        self.periodic_boundary = periodic_boundary
 
         self.random_offset = random_offset
 
@@ -509,6 +510,8 @@ class ImageModel:
 
         if self.drift_speed:
             if self.drift_by_transform:
+                if self.periodic_boundary:
+                    self.kwargs_affine['mode'] = 'wrap'
                 self.probe_positions = add_drift_by_transform(self.probe_positions,
                     self.scan_rotation, self.drift_speed, self.drift_angle,
                     kwargs_affine=self.kwargs_affine)

--- a/genSTEM/transform.py
+++ b/genSTEM/transform.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+def transform_drift_scan(scan_angle=0, drift_angle=0, drift_speed=0, xlen=100):
+    '''Generates the transformation matrix, T, which includes the transformation from scan rotation, Tr, and drift, Tt.
+    
+    Parameters
+    ----------
+    scan_angles: float, int
+        Scan rotation angles for the stack of images in degrees.
+    drift_angle: float, int
+        Angle of drift in degrees.
+    drift_speed: float, int
+    '''
+    arr = np.zeros(np.shape(drift_speed) + np.shape(drift_angle) + (3,3))
+    if np.shape(drift_speed):
+        drift_speed = drift_speed[:, None, None]
+    angle = np.deg2rad(drift_angle + scan_angle)
+    arr[...] = np.eye(3)
+    s_sin = drift_speed*(np.sin(angle)) 
+    s_cos = drift_speed*(np.cos(angle))
+    arr[..., 0,0] = 1 - s_cos
+    arr[..., 0,1] = -s_cos*xlen
+    arr[..., 0,2] = -s_cos
+    arr[..., 1,0] = -s_sin
+    arr[..., 1,1] = 1 - s_sin*xlen
+    arr[..., 1,2] = -s_sin
+    return arr.squeeze()
+    
+def add_shifts_and_rotation_to_transform(transform, image_shape, scan_rotation_deg, post_shifts=[0,0]):
+    shift1, shift2 = (np.array(image_shape) - 1) / 2
+    post_shift1, post_shift2 = post_shifts[::-1]
+
+    T = (
+        Affine2D().translate(shift1, shift2)
+        + Affine2D(transform)
+        .rotate_deg(scan_rotation_deg)
+        .translate(-shift1, -shift2)
+        .translate(post_shift1, post_shift2)
+    )
+    return T
+    

--- a/genSTEM/transform.py
+++ b/genSTEM/transform.py
@@ -1,5 +1,41 @@
 import numpy as np
 
+def extend_3D_ones(arr_of_2d):
+    '''Turn a 2D points array (N, 2) into (N, 3) by padding with ones.
+    Used to calculate transform matrix between two sets of points.
+    '''
+    return np.hstack([arr_of_2d, np.ones((len(arr_of_2d),1))])
+    
+def calculate_transform_matrix(points, prime):
+    '''Calculate the affine transform matrix needed to turn one set of points into another.
+
+    Parameters
+    ----------
+    points: array of shape (N, 2)
+    prime: array of shape (N, 2)
+
+    Returns
+    -------
+    transform matrix: array of shape (3,3)
+    '''
+    points = extend_3D_ones(points)
+    prime = extend_3D_ones(prime)
+    T, *_ = np.linalg.lstsq(points, prime, rcond=None)
+    return T.T
+
+def transform_points(points: "(2, N)", transform: "(3,3)"):
+    '''Transform a 2D points array (2, N) by a 3x3 transform
+
+    Turns the list of points into a (N, 3)  array, transforms
+    and then removes the third coordinate again.
+    Supports cp as well!
+    '''
+    shape = points.shape
+    points = points.reshape((2, -1))
+    points = extend_3D_ones(points.T).T
+    prime = transform @ points
+    return prime[:2].reshape(shape)
+    
 def transform_drift_scan(scan_angle=0, drift_angle=0, drift_speed=0, xlen=100):
     '''Generates the transformation matrix, T, which includes the transformation from scan rotation, Tr, and drift, Tt.
     
@@ -39,3 +75,74 @@ def add_shifts_and_rotation_to_transform(transform, image_shape, scan_rotation_d
     )
     return T
     
+def warp_image(img, scanrotation, drift_speed, drift_angle, nan=False, post_shifts=[0,0]):
+    drift_transform = transform_drift_scan(
+         -scanrotation,
+         drift_angle, 
+         drift_speed, 
+         img.shape[-2])
+    T = add_shifts_and_rotation_to_transform(drift_transform, img.shape, scanrotation, post_shifts)
+    cval = cp.nan if nan else 0 # value of pixels that were outside the image border
+    T2 = swap_transform_standard(T.get_matrix()).copy()
+    T3 = cp.array(T2)
+    T4 = cp.linalg.inv(T3)
+    return affine_transform(
+        img, 
+        T4,
+        order=1,
+        cval=cval)
+        
+def warp_images(images, scan_angles, drift_speed=0, drift_angle=0, nan=False):
+    warped_images = [warp_image(img, scan, drift_speed, drift_angle, nan=nan) for img, scan in zip(images, scan_angles)]
+    return cp.array(warped_images)
+    
+def warp_and_shift_images(images, scan_angles, drift_speed=0, drift_angle=0, nan=False):
+    warped_images = warp_images(images, scan_angles, drift_speed, drift_angle, nan=False)
+    shifts, _ = hybrid_correlation_images(warped_images)
+    if nan:
+        warped_images = warp_images(images, scan_angles, drift_speed, drift_angle, nan=nan)
+
+    translated_images = cp.zeros(images.shape)
+    for i, (img, shift) in enumerate(zip(warped_images, shifts)):
+        translated_images[i] = translate(img, shift[::-1], cval=nan)
+    return translated_images, shifts
+    
+def translate(img, shift, cval=0):
+    sx, sy = shift
+    if cval is True:
+        cval = np.nan
+    return affine_transform(
+        img,
+        cp.asarray(
+            np.linalg.inv(
+                swap_transform_standard(
+                    Affine2D().translate(sx, sy).get_matrix()))), 
+        order=1,
+        cval=cval)
+        
+def add_shifts_and_rotation_to_transform(transform, image_shape, scan_rotation_deg, post_shifts=[0,0]):
+    shift1, shift2 = (np.array(image_shape) - 1) / 2
+    post_shift1, post_shift2 = post_shifts[::-1]
+
+    T = (
+        Affine2D().translate(-shift1, -shift2)
+        + Affine2D(transform)
+        .rotate_deg(scan_rotation_deg)
+        .translate(shift1, shift2)
+        .translate(post_shift1, post_shift2)
+    )
+    return T
+
+
+def add_shifts_only_to_transform(transform, image_shape, scan_rotation_deg, ):#post_shifts=[0,0]):
+    shift1, shift2 = (np.array(image_shape) - 1) / 2
+    #post_shift1, post_shift2 = post_shifts[::-1]
+
+    T = (
+        Affine2D().translate(-shift1, -shift2)
+        + Affine2D(transform)
+        #.rotate_deg(scan_rotation_deg)
+        .translate(shift1, shift2)
+        #.translate(post_shift1, post_shift2)
+    )
+    return T

--- a/genSTEM/utils.py
+++ b/genSTEM/utils.py
@@ -46,6 +46,8 @@ def tukey_window(shape, alpha=0.1):
         filt2 = tukey(shape[1], alpha=alpha, sym=True)
     return filt1[:, None] * filt2
 
+def get_tukey_window(shape, alpha=0.1):
+    return cp.asarray(tukey_window(shape, alpha=alpha))
 
 def Gaussian2DFunc(YX, A=1, x0=0, y0=0, sigma=5, offset=0):
     y, x = YX


### PR DESCRIPTION
Added the option to apply drift as a transformation as an alternative to by each pixel.

Scipy affine_transform v<1.6.0 does not support anything other than mode='constant, so I used skimag's warp function. Warp does not handle cupy arrays. So it is converted to a numpy array, which is not ideal but functional.
Unfortunately this does not handle wrapping either and leaves an artifact.

@thomasaarholt Not sure if you have an idea to fix this.  Also, I'm not sure if you have a preference for affine_transform without wrapping functionality (fast) vs warp with wrapping functionality (slower). If you would rather affine_transform, I have commented out the return line for that method and we would just remove lines 513-514.

Also changed some drift_vector to drift_angle for consistency.